### PR TITLE
vsn field added to hello.app.src

### DIFF
--- a/src/hello.app.src
+++ b/src/hello.app.src
@@ -1,7 +1,7 @@
 % vim: filetype=erlang
 {application, hello,
   [{description, "JSON-RPC API toolkit"},
-   {vsn, "0.3"},
+   {vsn, git},
    {applications, [kernel, stdlib, cowboy, ex_uri, erlzmq, ibrowse]},
    {registered, [hello_supervisor, hello_stateless_zmq_supervisor]},
    {mod, {hello, []}},


### PR DESCRIPTION
Hello,

I added `vsn` field to hello.app.src, without it when we try to get hello with rebar error:

```
ERROR: Failed to get app value 'vsn' from '/home/user/ChicagoBoss/deps/hello/src/hello.app.src'
ERROR: 'get-deps' failed while processing /home/user/ChicagoBoss/deps/boss_db: rebar_abort
```
