### PR TITLE
Fix HTTP transport

### DIFF
--- a/src/hello_client.erl
+++ b/src/hello_client.erl
@@ -166,9 +166,9 @@ handle_info({?INCOMING_MSG, Message}, State) ->
     incoming_message(Message, State);
 handle_info(?PING, State = #client_state{transport_mod=TransportModule, transport_state=TransportState,
                                          protocol_mod=ProtocolMod, protocol_opts=ProtocolOpts}) ->
-    EncodeInfo = hello_proto:mime_type(ProtocolMod, ProtocolOpts),
+    {ok, MimeType} = hello_proto:mime_type(ProtocolMod, ProtocolOpts),
     BinaryPing = list_to_binary(atom_to_list(?PING)),
-    {ok, NewTransportState} = TransportModule:send_request(BinaryPing, EncodeInfo, TransportState),
+    {ok, NewTransportState} = TransportModule:send_request(BinaryPing, MimeType, TransportState),
     {noreply, State#client_state{transport_state = NewTransportState}};
 
 handle_info(Info, State = #client_state{transport_mod=TransportModule, transport_state=TransportState}) ->
@@ -217,7 +217,7 @@ outgoing_message(Request, From, State = #client_state{protocol_mod = ProtocolMod
                                                       transport_mod = TransportModule, transport_state = TransportState, async_request_map = AsyncMap}) ->
     case hello_proto:encode(ProtocolMod, ProtocolOpts, Request) of
         {ok, BinRequest} ->
-            MimeType = hello_proto:mime_type(ProtocolMod, ProtocolOpts),
+            {ok, MimeType} = hello_proto:mime_type(ProtocolMod, ProtocolOpts),
             case TransportModule:send_request(BinRequest, MimeType, TransportState) of
                 {ok, NewTransportState} ->
                     {ok, State#client_state{transport_state = NewTransportState, async_request_map = update_map(Request, From, AsyncMap)}};

--- a/src/hello_listener.erl
+++ b/src/hello_listener.erl
@@ -69,10 +69,14 @@ await_answer() ->
 handle_incoming_message(Context, ExUriURL, Binary) ->
     {ok, _, #listener{protocol = ProtocolMod, protocol_opts = ProtocolOpts, router = Router}} = hello_registry:lookup({listener, ExUriURL}),
     {ok, BinResp} = hello_proto:handle_incoming_message(Context, ProtocolMod, ProtocolOpts, Router, ExUriURL, Binary),
-    send(BinResp, Context).
+    send(BinResp, Context),
+    close(Context).
 
 send(BinResp, Context = #context{transport = TransportMod}) ->
     TransportMod:send_response(Context, BinResp).
+
+close(Context = #context{transport = TransportMod}) ->
+    TransportMod:close(Context).
 %% -------------------------------------------------------------------------------
 %% -- helpers TODO e.g. for keep alive mechanism
 start1(ExUriURL = #ex_uri{scheme = Scheme}, TransportOpts) ->

--- a/src/transports/hello_http_client.erl
+++ b/src/transports/hello_http_client.erl
@@ -77,18 +77,17 @@ http_send(Client, Request, MimeType, State = #http_state{url = URL, options = Op
             exit(normal)
     end.
 
-outgoing_message(Client, EncInfo, Body, State) ->
+outgoing_message(Client, MimeType, Body, State) ->
     Body1 = list_to_binary(Body),
-    AtomEncInfo = binary_to_atom(EncInfo, latin1),
-    case AtomEncInfo of
-        todo ->
+    case MimeType of
+        <<"application/json">> ->
             Body2 = binary:replace(Body1, <<"}{">>, <<"}$$${">>, [global]),
             Body3 = binary:replace(Body2, <<"]{">>, <<"]$$${">>, [global]),
             Body4 = binary:replace(Body3, <<"}[">>, <<"}$$$[">>, [global]),
             Bodies = binary:split(Body4, <<"$$$">>, [global]),
-            [ Client ! {?INCOMING_MSG, {ok, AtomEncInfo, SingleBody, State}} || SingleBody <- Bodies ];
+            [ Client ! {?INCOMING_MSG, {ok, SingleBody, State}} || SingleBody <- Bodies ];
         _NoJson ->
-            Client ! {?INCOMING_MSG, {ok, AtomEncInfo, Body1, State}}
+            Client ! {?INCOMING_MSG, {ok, Body1, State}}
     end.
 
 validate_options(Options) ->

--- a/src/transports/hello_http_listener.erl
+++ b/src/transports/hello_http_listener.erl
@@ -89,7 +89,7 @@ http_chunked_loop(Req, State) ->
         hello_closed ->
             {ok, Req, State};
         {hello_msg, _TParams, _Peer, BinResp} ->
-            cowboy_req:chunk(BinResp, Req),
+            ok = cowboy_req:chunk(BinResp, Req),
             http_chunked_loop(Req, State)
     end.
 


### PR DESCRIPTION
For #4.
HTTP transport does not have dns registration so you can test this like that:
```erlang
hello_client:start({local, ?MODULE}, "http://127.0.0.1:8080/test", [], [{decoder, hello_json}], [])
```