### PR TITLE
Service discovery

### DIFF
--- a/src/hello_lib.erl
+++ b/src/hello_lib.erl
@@ -1,5 +1,5 @@
 -module(hello_lib).
--export([get_in/2, to_binary/1, wrap/1, get/2, get/3]).
+-export([get_in/2, to_binary/1, wrap/1, get/2, get/3, dnssd_service_type/2, dnssd_service_type/3]).
 
 get_in(Map, Path) when is_list(Path) == false -> get_in(Map, Path);
 get_in(Value, []) -> Value;
@@ -23,3 +23,16 @@ to_binary(Term) -> unicode:characters_to_binary(io_lib:format("~p", [Term])).
 
 wrap(Requests) when is_list(Requests) -> Requests;
 wrap(Request) -> [Request].
+
+-spec dnssd_service_type(Scheme :: string(), App :: binary()) -> ServiceName :: binary().
+dnssd_service_type(Scheme, App) ->
+    SchemeBin = hello_lib:to_binary(Scheme), 
+    App1 = binary:replace(App, <<"/">>, <<"_">>, [global]), 
+    <<"_", SchemeBin/binary, "_", App1/binary, "._tcp.">>.
+
+-spec dnssd_service_type(Scheme :: string(), Host :: string(), Path :: string()) -> ServiceName :: binary().
+dnssd_service_type(Scheme, Host, Path) ->
+    SchemeBin = hello_lib:to_binary(Scheme), 
+    HostBin = hello_lib:to_binary(Host), 
+    PathBin = binary:replace(hello_lib:to_binary(Path), <<"/">>, <<"_">>, [global]), 
+    <<"_", SchemeBin/binary, "_", HostBin/binary, "_", PathBin/binary, "._tcp.">>.

--- a/src/transports/hello_http_client.erl
+++ b/src/transports/hello_http_client.erl
@@ -66,19 +66,8 @@ handle_info(_Msg, State) ->
 
 build_url(Scheme, Host, Path, Port) ->
     ex_uri:encode(#ex_uri{scheme = Scheme,
-                          authority = #ex_uri_authority{host = clean_host(Host), port = Port},
+                          authority = #ex_uri_authority{host = Host, port = Port},
                           path = Path}).
-
-clean_host(Host) ->
-    HostSize = erlang:byte_size(Host),
-    CleanedHost = case binary:match(Host, <<".local.">>) of
-        {M, L} when HostSize == (M + L) ->
-            <<HostCuted:M/binary, _/binary>> = Host,
-            HostCuted;
-        _ ->
-            Host
-    end,
-    binary_to_list(CleanedHost).
 
 content_type(Signarute) ->
     Json = hello_json:signature(),

--- a/src/transports/hello_http_client.erl
+++ b/src/transports/hello_http_client.erl
@@ -22,7 +22,7 @@
 -module(hello_http_client).
 
 -behaviour(hello_client).
--export([init_transport/2, send_request/3, terminate_transport/2, handle_info/2]).
+-export([init_transport/2, send_request/3, terminate_transport/2, handle_info/2, update_service/2]).
 -export([http_send/4]).
 
 -include_lib("ex_uri/include/ex_uri.hrl").
@@ -43,8 +43,7 @@
 init_transport(URL, Options) ->
     case validate_options(Options) of
         {ok, ValOpts} ->
-            http_connect_url(URL),
-            {ok, #http_state{url = ex_uri:encode(URL), scheme = URL#ex_uri.scheme, path = URL#ex_uri.path, options = ValOpts}};
+            {browse, #http_state{url = ex_uri:encode(URL), scheme = URL#ex_uri.scheme, path = URL#ex_uri.path, options = ValOpts}};
         {error, Reason} ->
             ?LOG_ERROR("Invalid options for init http client, reason: ~p", [Reason]),
             {error, Reason}
@@ -59,11 +58,10 @@ send_request(_, _, State) ->
 terminate_transport(_Reason, _State) ->
     ok.
 
-handle_info({dnssd, _Ref, {resolve,{Host, Port, _Txt}}}, State = #http_state{scheme = Scheme, path = Path}) ->
-    ?LOG_INFO("dnssd Service: ~p:~w", [Host, Port]),
-    {noreply, State#http_state{url = build_url(Scheme, Host, Path, Port)}};
-handle_info({dnssd, _Ref, Msg}, State) ->
-    ?LOG_INFO("dnssd Msg: ~p", [Msg]),
+update_service({Host, Port, _Txt}, State = #http_state{scheme = Scheme, path = Path}) ->
+    {ok, State#http_state{url = build_url(Scheme, Host, Path, Port)}}.
+
+handle_info(_Msg, State) ->
     {noreply, State}.
 
 build_url(Scheme, Host, Path, Port) ->
@@ -142,9 +140,3 @@ validate_options([_ | R], Opts) ->
     validate_options(R, Opts);
 validate_options([], Opts) ->
     {ok, Opts}.
-
-http_connect_url(#ex_uri{authority = #ex_uri_authority{host = Host}, path = [$/|Path]}) ->
-    dnssd:resolve(list_to_binary(Path), <<"_", (list_to_binary(Host))/binary, "._tcp.">>, <<"local.">>),
-    ok;
-http_connect_url(URI) ->
-    URI.

--- a/src/transports/hello_zmq_client.erl
+++ b/src/transports/hello_zmq_client.erl
@@ -22,7 +22,7 @@
 -module(hello_zmq_client).
 
 -behaviour(hello_client).
--export([init_transport/2, send_request/3, terminate_transport/2, handle_info/2]).
+-export([init_transport/2, send_request/3, terminate_transport/2, handle_info/2, update_service/2]).
 
 -include_lib("ex_uri/include/ex_uri.hrl").
 -include("hello.hrl").
@@ -36,8 +36,8 @@
 
 init_transport(URI, _Options) ->
     {ok, Socket} = ezmq:socket([{type, dealer}, {active, true}]),
-    ok = ezmq_connect_url(Socket, URI),
-    {ok, #zmq_state{socket = Socket, uri = URI}}.
+    Res = ezmq_connect_url(Socket, URI),
+    {Res, #zmq_state{socket = Socket, uri = URI}}.
 
 send_request(Message, Signature, State = #zmq_state{socket = Socket}) ->
     ezmq:send(Socket, [Signature, Message]),
@@ -48,15 +48,12 @@ send_request(Message, Signature, State = #zmq_state{socket = Socket}) ->
 terminate_transport(_Reason, #zmq_state{socket = Socket}) ->
     ezmq:close(Socket).
 
-handle_info({dnssd, _Ref, {resolve,{Host, Port, _Txt}}}, State = #zmq_state{uri = URI, socket = Socket}) ->
-    ?LOG_INFO("dnssd Service: ~p:~w", [Host, Port]),
+update_service({Host, Port, _Txt}, State = #zmq_state{uri = URI, socket = Socket}) ->
     Protocol = zmq_protocol(URI),
     R = ezmq:connect(Socket, tcp, clean_host(Host), Port, [Protocol]),
-    ?LOG_INFO("ezmq:connect: ~p", [R]),
-    {noreply, State};
-handle_info({dnssd, _Ref, Msg}, State) ->
-    ?LOG_INFO("dnssd Msg: ~p", [Msg]),
-    {noreply, State};
+    ?LOG_DEBUG("ezmq:connect: ~p", [R]),
+    {ok, State}.
+
 handle_info({zmq, _Socket, [Signature, Msg]}, State) ->
     {?INCOMING_MSG, {ok, Signature, Msg, State}};
 handle_info({zmq, _Socket, [<<>>, Signature, Msg]}, State) ->
@@ -69,18 +66,13 @@ zmq_protocol(#ex_uri{scheme = "zmq-tcp6"}) -> inet6.
 
 %% use dnssd to resolve port AND host
 %% map host to Type and Path to Name
-ezmq_connect_url(_Socket, #ex_uri{authority = #ex_uri_authority{host = Host, port = undefined}, path = [$/|Path]}) ->
-    dnssd:resolve(list_to_binary(Path), <<"_", (list_to_binary(Host))/binary, "._tcp.">>, <<"local.">>),
-    ok;
+ezmq_connect_url(_Socket, #ex_uri{authority = #ex_uri_authority{port = undefined}}) ->
+    browse;
 
 ezmq_connect_url(Socket, URI = #ex_uri{authority = #ex_uri_authority{host = Host, port = Port}}) ->
     Protocol = zmq_protocol(URI),
-    case ezmq_ip(Protocol, Host) of
-        {ok, IP} ->
-            ezmq:connect(Socket, tcp, IP, Port, [Protocol]);
-        Other ->
-            Other
-    end.
+    {ok, IP} = ezmq_ip(Protocol, Host),
+    ezmq:connect(Socket, tcp, IP, Port, [Protocol]).
 
 ezmq_ip(inet, "*") -> {ok, {0,0,0,0}};
 ezmq_ip(inet, Host) -> inet:parse_ipv4_address(Host);

--- a/src/transports/hello_zmq_client.erl
+++ b/src/transports/hello_zmq_client.erl
@@ -49,8 +49,8 @@ terminate_transport(_Reason, #zmq_state{socket = Socket}) ->
     ezmq:close(Socket).
 
 update_service({Host, Port, _Txt}, State = #zmq_state{uri = URI, socket = Socket}) ->
-    Protocol = zmq_protocol(URI),
-    R = ezmq:connect(Socket, tcp, clean_host(Host), Port, [Protocol]),
+    Protocol = hello_zmq_listener:zmq_protocol(URI),
+    R = ezmq:connect(Socket, tcp, Host, Port, [Protocol]),
     ?LOG_DEBUG("ezmq:connect: ~p", [R]),
     {ok, State}.
 
@@ -61,38 +61,9 @@ handle_info({zmq, _Socket, [<<>>, Signature, Msg]}, State) ->
 
 %% --------------------------------------------------------------------------------
 %% -- helpers
-zmq_protocol(#ex_uri{scheme = "zmq-tcp"})  -> inet;
-zmq_protocol(#ex_uri{scheme = "zmq-tcp6"}) -> inet6.
-
-%% use dnssd to resolve port AND host
-%% map host to Type and Path to Name
-ezmq_connect_url(_Socket, #ex_uri{authority = #ex_uri_authority{port = undefined}}) ->
-    browse;
+ezmq_connect_url(_Socket, #ex_uri{authority = #ex_uri_authority{port = undefined}}) -> browse;
 
 ezmq_connect_url(Socket, URI = #ex_uri{authority = #ex_uri_authority{host = Host, port = Port}}) ->
-    Protocol = zmq_protocol(URI),
-    {ok, IP} = ezmq_ip(Protocol, Host),
+    Protocol = hello_zmq_listener:zmq_protocol(URI),
+    {ok, IP} = hello_zmq_listener:ezmq_ip(Protocol, Host),
     ezmq:connect(Socket, tcp, IP, Port, [Protocol]).
-
-ezmq_ip(inet, "*") -> {ok, {0,0,0,0}};
-ezmq_ip(inet, Host) -> inet:parse_ipv4_address(Host);
-
-ezmq_ip(inet6, "*") -> {ok, {0,0,0,0,0,0,0,0}};
-ezmq_ip(inet6, Host) ->
-    case re:run(Host, "^\\[(.*)\\]$", [{capture, all, list}]) of
-        {match, ["[::1]", IP]} ->
-            inet:parse_ipv6_address(IP);
-        _ ->
-            inet:parse_ipv6_address(Host)
-    end.
-
-clean_host(Host) ->
-    HostSize = erlang:byte_size(Host),
-    CleanedHost = case binary:match(Host, <<".local.">>) of
-        {M, L} when HostSize == (M + L) ->
-            <<HostCuted:M/binary, _/binary>> = Host,
-            HostCuted;
-        _ ->
-            Host
-    end,
-    binary_to_list(CleanedHost).

--- a/src/transports/hello_zmq_listener.erl
+++ b/src/transports/hello_zmq_listener.erl
@@ -28,6 +28,9 @@
 -behaviour(gen_server).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
+%% for hello_zmq_client
+-export([ezmq_ip/2, zmq_protocol/1]).
+
 -include_lib("ex_uri/include/ex_uri.hrl").
 -include("hello.hrl").
 -include("hello_log.hrl").


### PR DESCRIPTION
All services register with type `_<SCHEME>_<HANDLER_NAME>._tcp.` (I replace / to _ in HANDLER_NAME)
Clients browse this type via `dnssd` and use first available. If one service down  then this one will be removed from client services list and client will use next available.

relate to #14 