### PR TITLE
Add some http listener options

### DIFF
--- a/src/hello_proto.erl
+++ b/src/hello_proto.erl
@@ -114,7 +114,7 @@ handle_internal(_Context, ?PING) -> {ok, ?PONG}.
 %% -- Encoding/Decoding
 encode(Mod, Opts, Request) -> Mod:encode(Request, Opts).
 decode(_Mod, _Opts, ?INTERNAL_SIGNATURE, Message, _Type) -> {internal, Message};
-decode(_Mod, _Opts, {<<>>, ?INTERNAL_SIGNATURE} = Signature, Message, _Type) -> {internal, Message};
+decode(_Mod, _Opts, {<<>>, ?INTERNAL_SIGNATURE} = _Signature, Message, _Type) -> {internal, Message};
 decode(Mod, Opts, Signature, Message, Type) when is_atom(Mod) ->
     case signature(Mod, Opts) of
         Signature -> Mod:decode(Message, Opts, Type);


### PR DESCRIPTION
You can redefine `acceptors` and `max_connections` for cowboy listener:
```erlang
ListenerOpts = [{http_acceptors, 100}, {http_max_connections, 2048}],
hello:start_listener("http://127.0.0.1:8080", ListenerOpts, hello_proto_jsonrpc, [], hello_router),
```