### PR TITLE
Add trap_exit to hello_client

### DIFF
--- a/src/hello_client.erl
+++ b/src/hello_client.erl
@@ -132,6 +132,7 @@ timeout_call(Client, Call, Timeout) ->
 
 %% @hidden
 init({URI, TransportOpts, ProtocolOpts, ClientOpts}) ->
+    process_flag(trap_exit, true),
     case (catch ex_uri:decode(URI)) of
         {ok, URIRec = #ex_uri{}, _} ->
             case uri_client_module(URIRec) of


### PR DESCRIPTION
This needed to when we are stopping supervised client.
If trap_exit = false and we stop gen_server via supervisor:terminate_child then gen_server:terminate doesn't call