### PR TITLE
Add hidden_params for logging

### DIFF
--- a/src/hello.app.src
+++ b/src/hello.app.src
@@ -8,6 +8,8 @@
    {env, [
        %% metrics is list of packets | request | response | service | handler | binding | listener | client
        {metrics, [packets, request, response, service, handler, binding, listener, client]},
+       {hidden_params, []},
+       {log_formatter, json}, %% native | json
        {default_protocol, hello_proto_jsonrpc},
        {transports, []}
    ]}

--- a/src/hello.erl
+++ b/src/hello.erl
@@ -53,6 +53,7 @@ start(_Type, _StartArgs) ->
     {ok, Supervisor} = hello_supervisor:start_link(),
     {ok, Metrics} = application:get_env(hello, metrics),
     hello_metrics:start_subscriptions(Metrics),
+    hello_log:init(),
     {ok, Supervisor, undefined}.
 
 % @doc Callback for application behaviour.

--- a/src/hello_log.erl
+++ b/src/hello_log.erl
@@ -21,14 +21,93 @@
 % @private
 -module(hello_log).
 
--export([fmt_response/1, fmt_request/1]).
+-export([fmt_response/1, fmt_request/1, init/0]).
+-export([format_params/2, to_binary/1]). % for test
 
 -include("hello.hrl").
+
+
+init() ->
+    HiddenParams0 = application:get_env(hello, hidden_params, []),
+    HiddenParams = [to_binary(P) || P <- HiddenParams0],
+    application:set_env(hello, hidden_params, HiddenParams).
+
 
 %% --------------------------------------------------------------------------------
 %% -- Formaters
 fmt_request(#request{method = Method, args = Params}) ->
-    <<"method: ", (hello_json:encode(Method))/binary, ", params: ", (hello_json:encode(Params))/binary>>.
+    <<"method: ", (encode(Method))/binary, ", params: ", (format_params(Params, req))/binary>>.
 
 fmt_response(ignore) -> ["ignored"];
+fmt_response({ok, Result}) -> <<(format_params(Result, resp))/binary>>;
 fmt_response(Result) -> io_lib:format("~4096p", [Result]).
+
+
+%% --------------------------------------------------------------------------------
+%% -- Helpers
+format_params(Params0, Type) -> 
+    HiddenParams = application:get_env(hello, hidden_params, []),
+    Params = case Type of
+        req -> Params0;
+        resp -> params_to_binary(Params0)
+    end,
+    format_params_(Params, HiddenParams).
+
+params_to_binary(Params) when is_list(Params) ->
+    F = fun({Key, Value}) -> {hello_lib:to_binary(Key), params_to_binary(Value)};
+           (Param) -> Param
+        end,
+    [F(Param) || Param <- Params];
+params_to_binary(Params) when is_map(Params) ->
+    Keys = maps:keys(Params),
+    lists:foldl(fun(Key, Map) -> 
+                    maps:put(hello_lib:to_binary(Key),
+                             params_to_binary(maps:get(Key, Map)), 
+                             maps:remove(Key, Map))
+                end, Params, Keys);
+params_to_binary(Params) -> Params.
+
+to_binary([]) -> [];
+to_binary([Head | Tail]) -> [hello_lib:to_binary(Head) | to_binary(Tail)];
+to_binary(Key) -> hello_lib:to_binary(Key).
+
+format_params_(Params, []) -> encode(Params);
+
+format_params_(Params, HiddenParams) ->
+    NewParams = lists:foldl(fun F([Key | [_|_] = Tail], Map) when is_map(Map) -> 
+                                   F1 = fun() -> 
+                                            maps:update(Key, F(Tail, maps:get(Key, Map)), Map)
+                                        end,
+                                   is_key(Key, Map, F1);
+                                F([Key |[_|_] = Tail], List) when is_list(List) ->
+                                   F1 = fun() -> 
+                                            lists:keyreplace(Key, 1, List, {Key, F(Tail, proplists:get_value(Key, List))})
+                                        end,
+                                   is_key(Key, List, F1);
+                                F([Key], MapOrList) -> hidden_key(Key, MapOrList);
+                                F(Key, MapOrList) -> hidden_key(Key, MapOrList)
+                            end, Params, HiddenParams),
+    encode(NewParams).
+
+is_key(Key, Map, Fun) when is_map(Map) ->
+    case maps:is_key(Key, Map) of
+        true -> Fun();
+        false -> Map
+    end;
+is_key(Key, List, Fun) when is_list(List) ->
+    case lists:keymember(Key, 1, List) of
+        true -> Fun();
+        false -> List
+    end.
+
+hidden_key(Key, Map) when is_map(Map) ->
+    is_key(Key, Map, fun() -> maps:update(Key, <<"HIDDEN">>, Map) end);
+hidden_key(Key, List) when is_list(List) ->
+    is_key(Key, List, fun() -> lists:keyreplace(Key, 1, List, {Key, <<"HIDDEN">>}) end);
+hidden_key(_, Other) -> Other.
+
+encode(Data) -> 
+    case application:get_env(hello, log_formatter, native) of
+        json -> hello_json:encode(Data);
+        _ -> list_to_binary(io_lib:format("~4096p", [Data]))
+    end.

--- a/test/log_SUITE.erl
+++ b/test/log_SUITE.erl
@@ -1,0 +1,91 @@
+-module(log_SUITE).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+
+% ---------------------------------------------------------------------
+% -- test cases
+map(_Config) ->
+    ReqMap = #{<<"a">> => 2, <<"b">> => 1, <<"c">> => #{<<"d">> => "d", <<"e">> => "e"}},
+    RepMap = #{a => 2, b => 1, c => #{d => "d", e => "e"}},
+
+    init_log([]),
+    true = (hello_json:encode(ReqMap) == hello_log:format_params(ReqMap, req)),
+    true = (hello_json:encode(RepMap) == hello_log:format_params(RepMap, resp)),
+
+    init_log([a]),
+    true = (hello_json:encode(ReqMap#{<<"a">> => <<"HIDDEN">>}) 
+            == hello_log:format_params(ReqMap, req)),
+    true = (hello_json:encode(RepMap#{a => <<"HIDDEN">>}) 
+            == hello_log:format_params(RepMap, resp)),
+
+    init_log([[c, d]]),
+    true = (hello_json:encode(ReqMap#{<<"c">> => #{<<"d">> => <<"HIDDEN">>, <<"e">> => "e"}}) 
+            == hello_log:format_params(ReqMap, req)),
+    true = (hello_json:encode(RepMap#{c => #{d => <<"HIDDEN">>, e => "e"}}) 
+            == hello_log:format_params(RepMap, resp)),
+    ok.
+
+list(_Config) ->
+    List = [{a, "a"}, {b, 1}, {c, [{d, "d"}]}],
+
+    init_log([]),
+    true = (hello_json:encode(List) == hello_log:format_params(List, resp)),
+
+    init_log([a]),
+    true = (hello_json:encode(lists:keyreplace(a, 1, List, {a, <<"HIDDEN">>})) 
+            == hello_log:format_params(List, resp)),
+    init_log([<<"a">>]),
+    true = (hello_json:encode(lists:keyreplace(a, 1, List, {a, <<"HIDDEN">>})) 
+            == hello_log:format_params(List, resp)),
+
+    init_log([[c, d]]),
+    true = (hello_json:encode(lists:keyreplace(c, 1, List, {c, [{d, <<"HIDDEN">>}]})) 
+            == hello_log:format_params(List, resp)),
+    ok.
+
+mixed(_Config) ->
+    Map = #{a => 2, b => [{r, 1}], c => #{d => "d"}, e => #{f => #{x => "x"}}},
+
+    init_log([[c, d]]),
+    true = (hello_json:encode(Map#{c => #{d => <<"HIDDEN">>}}) 
+            == hello_log:format_params(Map, resp)),
+
+    init_log([[b, r]]),
+    true = (hello_json:encode(Map#{b => #{r => <<"HIDDEN">>}}) 
+            == hello_log:format_params(Map, resp)),
+
+    init_log([[e, f, x]]),
+    true = (hello_json:encode(Map#{e => #{f => #{x => <<"HIDDEN">>}}}) 
+            == hello_log:format_params(Map, resp)),
+
+    init_log([a]),
+    [<<"a">>] = application:get_env(hello, hidden_params, []),
+    true = (hello_json:encode([<<"arg">>]) 
+            == hello_log:format_params([<<"arg">>], req)),
+    true = (hello_json:encode([<<"arg">>]) 
+            == hello_log:format_params([<<"arg">>], resp)),
+    true = (hello_json:encode(["arg"]) 
+            == hello_log:format_params(["arg"], req)),
+    true = (hello_json:encode(["arg"]) 
+            == hello_log:format_params(["arg"], resp)),
+    ok.
+
+% ---------------------------------------------------------------------
+% -- common_test callbacks
+all() -> [map, 
+          list,
+          mixed
+         ].
+
+init_log(Params) ->
+    application:set_env(hello, hidden_params, Params),
+    hello_log:init().
+
+init_per_suite(Config) ->
+    application:set_env(hello, log_formatter, json),
+    Config.
+
+end_per_suite(_Config) ->
+    application:set_env(hello, hidden_params, []),
+    ok.


### PR DESCRIPTION
This PR adds two options for logging:

1) `logger_formatter`: `json | native`
How to print request and response in logs. `json` by default

2) `hidden_params`: `[atom() | binary() | [atom() | binary()]]`
Which keys will be hidden. For example we have request like this:
```json
{
 "key1": "value", 
 "key2":  {
     "key3": "value"
 },
 "key4":  {
     "key5": {
         "key6": "value"
     }
 }
}
``` 

and we want to hide `key1` and `key6`, we should use `hidden_params = [key1, [key4, key5, key6]]`.
`[]` by default

Relate to #58 