### PR TITLE
Metrics refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,29 @@ To write all requests for a module hello_handler_example to a file use:
         ]}
     ]}
 
+# Metrics
+
+Hello collects the following metrics via exometer_core and reports it to the each registered reporters: 
+
+| Exometer ID                                       | Type      | Data Types | Report Time |
+|---------------------------------------------------|-----------|------------|-------------|
+| [hello, server, Name, packets_in, size]           | histogram | max, mean  |   1000      |
+| [hello, server, Name, packets_in, per_sec]        | spiral    | one        |   1000      |
+| [hello, server, Name, packets_out, size]          | histogram | max, mean  |   1000      |
+| [hello, server, Name, packets_out, per_sec]       | spiral    | one        |   1000      |
+| [hello, server, Name, requests, ReqType, per_sec] | spiral    | one        |   1000      |
+| [hello, server, Name, request, handle_time]       | histogram | max, mean  |   1000      |
+| [hello, client, Name, requests, ReqType, per_sec] | spiral    | one        |   1000      |
+| [hello, client, Name, request, handle_time]       | histogram | max, mean  |   1000      |
+| [hello, client, Name, ping_pong_latency]          | histogram | max, mean  |   1000      |
+| [hello, services]                                 | counter   | value      |   2000      |
+| [hello, bindings]                                 | counter   | value      |   2000      |
+| [hello, listeners]                                | counter   | value      |   2000      |
+| [hello, clients]                                  | counter   | value      |   2000      |
+
+Name - server or client name
+ReqType = [ok, error, internal]
+
 # Elixir
 
 You can use hello with Elixir environment via `Hello` and `Hello.Client` modules which are delegating `:hello` and `:hello_client`

--- a/include/hello.hrl
+++ b/include/hello.hrl
@@ -4,6 +4,7 @@
 %% ----------------------------------------------------------------------------------------------------
 %% -- these records are used for abstraction of request and responses independent of the used protocol
 -record(context, {
+    listener_id             :: term(),
     connection_pid          :: pid(),
     transport               :: module(),
     transport_pid           :: pid(),

--- a/src/hello.app.src
+++ b/src/hello.app.src
@@ -6,9 +6,8 @@
    {vsn, git},
    {mod, {hello, []}},
    {env, [
-       %% metrics is list of packets | request | response | service | handler | binding | listener | client
        {dnssd, false},
-       {metrics, [packets, request, response, service, handler, binding, listener, client]},
+       {metrics, [client, server, common]},
        {default_protocol, hello_proto_jsonrpc},
        {transports, []},
        {server_timeout, 10000},

--- a/src/hello.erl
+++ b/src/hello.erl
@@ -25,7 +25,7 @@
 
 -export([start/2, stop/1, start/0]).
 -export([start_service/2, stop_service/1,
-         start_listener/1, start_listener/2, start_listener/5,
+         start_listener/1, start_listener/2, start_listener/5, start_listener/6,
          stop_listener/1, call_service/2, call_service/3]).
 -export([bind_handler/3, bind/2, bind/3, bind/7, unbind/2]).
 
@@ -53,8 +53,7 @@ start() ->
 start(_Type, _StartArgs) ->
     ok = start_dnssd(),
     {ok, Supervisor} = hello_supervisor:start_link(),
-    {ok, Metrics} = application:get_env(hello, metrics),
-    hello_metrics:start_subscriptions(Metrics),
+    hello_metrics:start_subscriptions(),
     {ok, Supervisor, undefined}.
 
 % @doc Callback for application behaviour.
@@ -131,8 +130,14 @@ start_listener(URL, TransportOpts) ->
                      ProtocolOpts :: list(), RouterMod :: module()) ->
     {ok, listener_ref()} | {error, Reason :: term()}.
 start_listener(URL, TransportOpts, Protocol, ProtocolOpts, RouterMod) ->
+    start_listener(undefined, URL, TransportOpts, Protocol, ProtocolOpts, RouterMod).
+    
+-spec start_listener(Name :: term(), URL :: url(), TransportOpts :: list(), Protocol :: module(),
+                     ProtocolOpts :: list(), RouterMod :: module()) ->
+    {ok, listener_ref()} | {error, Reason :: term()}.
+start_listener(Name, URL, TransportOpts, Protocol, ProtocolOpts, RouterMod) ->
     on_ex_uri(URL, fun(ExUriURL) ->
-                           hello_listener:start(ExUriURL, TransportOpts, Protocol, ProtocolOpts, RouterMod)
+                           hello_listener:start(Name, ExUriURL, TransportOpts, Protocol, ProtocolOpts, RouterMod)
                    end).
 
 -spec stop_listener(URL :: url()) -> ok | {error, Reason :: term()}.

--- a/src/hello_metrics.erl
+++ b/src/hello_metrics.erl
@@ -22,20 +22,26 @@
 
 -module (hello_metrics).
 
--export([start_subscriptions/0, start_subscriptions/1, start_subscriptions/2,
+-export([subscribe_client/1, subscribe_server/1,
+         unsubscribe_client/1, unsubscribe_server/1,
+         start_subscriptions/0, start_subscriptions/1, start_subscriptions/2,
          subscriptions/0, subscriptions/1]).
 
--export([packet_in/1,
-         packet_out/1, 
-         ok_request/0, ok_request/1,
-         internal_request/0,
-         error_request/0,
-         response/0,
-         handle_request_time/1,
+-export([packet_in/2,
+         packet_out/2, 
+         ok_request/1, ok_request/2,
+         internal_request/1,
+         error_request/1,
+         handle_request_time/2,
          service/1,
          binding/1,
          listener/1,
-         client/1]).
+         client/1,
+         client_ok_request/1,
+         client_error_request/1,
+         client_internal_request/1,
+         client_request_handle_time/2,
+         client_ping_pong_latency/2]).
 
 -include("hello_log.hrl").
 
@@ -45,14 +51,88 @@
 -type extra() :: exometer_report:extra(). 
 -type subscription() :: {metric(), datapoint(), interval(), extra()}.
 -type subscriptions() :: [subscription()].
--type metrics_type() :: packets | request | response | service | 
-                        handler | binding | listener | client.
+-type metrics_type() :: client | server | common.
 
 -export_type([metrics_type/0]).
 
--define(ALL_TYPES, [packets, request, response, service, handler, binding, listener, client]).
--define(DEFAULT_INTERVAL, 500).
--define(FAST_INTERVAL, trunc(?DEFAULT_INTERVAL / 3)).
+-define(ALL_TYPES, [client, server, common]).
+-define(DEFAULT_INTERVAL, 1000).
+-define(DEFAULT_INTERVAL_2, ?DEFAULT_INTERVAL * 2).
+
+-spec subscribe_client(Name :: list()) -> list().
+subscribe_client(Name) ->
+    io:format("Subscriber client ~p~n", [Name]),
+    {ok, Metrics} = application:get_env(hello, metrics),
+    case lists:member(client, Metrics) of
+        true -> subscribe_client_(Name);
+        false -> []
+    end.
+
+% @private
+subscribe_client_(Name) ->
+    [exometer_report:subscribe(Reporter, Metric, DataPoint, ?DEFAULT_INTERVAL, Tags, true) 
+     || {Metric, DataPoint, Tags} <- client_metrics(Name),
+        {Reporter, _} <- exometer_report:list_reporters()].
+
+% @private
+client_metrics(Name) when is_atom(Name) -> 
+    Tags = [{client, {from_name, 3}}],
+    TagsWithType = Tags ++ [{type, {from_name, 5}}],
+    [{[hello, client, Name, requests, ok, per_sec], one, TagsWithType},
+     {[hello, client, Name, requests, error, per_sec], one, TagsWithType},
+     {[hello, client, Name, requests, internal, per_sec], one, TagsWithType},
+     {[hello, client, Name, request, handle_time], max, Tags},
+     {[hello, client, Name, request, handle_time], mean, Tags},
+     {[hello, client, Name, ping_pong_latency], max, Tags},
+     {[hello, client, Name, ping_pong_latency], mean, Tags}];
+client_metrics(Name) -> client_metrics(convert_name(Name)).
+
+-spec unsubscribe_client(Name :: list()) -> list().
+unsubscribe_client(Name) ->
+    [begin
+         exometer_report:unsubscribe_all(Reporter, Metric),
+         exometer:delete(Metric)
+     end || {Metric, _, _} <- client_metrics(Name),
+            {Reporter, _} <- exometer_report:list_reporters()].
+
+-spec subscribe_server(Name :: list()) -> list().
+subscribe_server(Name) ->
+    {ok, Metrics} = application:get_env(hello, metrics),
+    case lists:member(server, Metrics) of
+        true -> subscribe_server_(Name);
+        false -> []
+    end.
+
+% @private
+subscribe_server_(Name) ->
+    [exometer_report:subscribe(Reporter, Metric, DataPoint, ?DEFAULT_INTERVAL, Tags, true)
+     || {Metric, DataPoint, Tags} <- server_metrics(Name),
+        {Reporter, _} <- exometer_report:list_reporters()].
+
+-spec unsubscribe_server(Name :: list()) -> list().
+unsubscribe_server(Name) ->
+    [begin 
+         exometer_report:unsubscribe_all(Reporter, Metric),
+         exometer:delete(Metric)
+     end || {Metric, _, _} <- server_metrics(Name),
+            {Reporter, _} <- exometer_report:list_reporters()].
+
+% @private
+server_metrics(Name) when is_atom(Name) -> 
+    Tags = [{server, {from_name, 3}}],
+    TagsWithType = Tags ++ [{type, {from_name, 5}}],
+    [{[hello, server, Name, requests, ok, per_sec], one, TagsWithType},
+     {[hello, server, Name, requests, error, per_sec], one, TagsWithType},
+     {[hello, server, Name, requests, internal, per_sec], one, TagsWithType},
+     {[hello, server, Name, request, handle_time], max, Tags},
+     {[hello, server, Name, request, handle_time], mean, Tags},
+     {[hello, server, Name, packets_in, size], max, Tags},
+     {[hello, server, Name, packets_in, size], mean, Tags},
+     {[hello, server, Name, packets_in, per_sec], one, Tags},
+     {[hello, server, Name, packets_out, size], max, Tags},
+     {[hello, server, Name, packets_out, size], mean, Tags},
+     {[hello, server, Name, packets_out, per_sec], one, Tags}];
+server_metrics(Name) -> server_metrics(convert_name(Name)).
 
 -spec start_subscriptions() -> list().
 start_subscriptions() ->
@@ -75,89 +155,75 @@ subscriptions() ->
 subscriptions(Types) when is_list(Types) -> 
     lists:flatten([subscriptions(Type) || Type <- Types]);
 
-subscriptions(packets) ->
-    [{[hello, packet_in], value, ?DEFAULT_INTERVAL},
-     {[hello, packet_in, size], median, ?DEFAULT_INTERVAL},
-     {[hello, packet_in, size], min, ?DEFAULT_INTERVAL},
-     {[hello, packet_in, size], max, ?DEFAULT_INTERVAL},
-     {[hello, packet_in, per_sec], one, ?FAST_INTERVAL},
-     {[hello, packet_out], value, ?DEFAULT_INTERVAL},
-     {[hello, packet_out, size], median, ?DEFAULT_INTERVAL},
-     {[hello, packet_out, size], min, ?DEFAULT_INTERVAL},
-     {[hello, packet_out, size], max, ?DEFAULT_INTERVAL},
-     {[hello, packet_out, per_sec], one, ?FAST_INTERVAL}];
-subscriptions(request)  ->
-    [{[hello, request], value, ?DEFAULT_INTERVAL},
-     {[hello, request, ok], value, ?DEFAULT_INTERVAL},
-     {[hello, request, error], value, ?DEFAULT_INTERVAL},
-     {[hello, request, internal], value, ?DEFAULT_INTERVAL},
-     {[hello, request, per_sec], one, ?FAST_INTERVAL}];
-subscriptions(response) -> 
-    [{[hello, response], value, ?DEFAULT_INTERVAL},
-     {[hello, response, per_sec], one, ?FAST_INTERVAL}];
-subscriptions(handler) -> 
-    [{[hello, handle_request_time], max, ?DEFAULT_INTERVAL}, 
-     {[hello, handle_request_time], mean, ?DEFAULT_INTERVAL}];
-subscriptions(service) -> [{[hello, services], value, ?DEFAULT_INTERVAL}];
-subscriptions(binding) -> [{[hello, bindings], value, ?DEFAULT_INTERVAL}];
-subscriptions(listener) -> [{[hello, listeners], value, ?DEFAULT_INTERVAL}];
-subscriptions(client) -> [{[hello, clients], value, ?DEFAULT_INTERVAL}];
+subscriptions(client) -> [];
+subscriptions(server) -> [];
+subscriptions(common) -> 
+    [{[hello, services], value, ?DEFAULT_INTERVAL_2},
+     {[hello, bindings], value, ?DEFAULT_INTERVAL_2},
+     {[hello, listeners], value, ?DEFAULT_INTERVAL_2},
+     {[hello, clients], value, ?DEFAULT_INTERVAL_2}];
 
 subscriptions(Type) -> 
     ?LOG_DEBUG("Hello metrics received unknown subscription type ~p.", [Type], [], ?LOGID50), [].
 
+%% --------------------------------------------------------------------------------
+%% -- Collect Metrics
+packet_in(Name, Size) -> packet(convert_name(Name), packets_in, Size).
 
-% @private
-packet_in(Size) -> packet(packet_in, Size).
+packet_out(Name, Size) -> packet(convert_name(Name), packets_out, Size).
 
-% @private
-packet_out(Size) -> packet(packet_out, Size).
+ok_request(Name) -> ok_request(convert_name(Name), 1).
 
-% @private
-ok_request() -> ok_request(1).
+ok_request(Name, Value) -> request(convert_name(Name), ok, Value).
 
-% @private
-ok_request(Value) -> request(ok, Value).
+internal_request(Name) -> request(convert_name(Name), internal, 1).
 
-% @private
-internal_request() -> request(internal, 1).
+error_request(Name) -> request(convert_name(Name), error, 1).
 
-% @private
-error_request() -> request(error, 1).
+handle_request_time(Name, Time) ->
+    exometer:update_or_create([hello, server, convert_name(Name), request, handle_time], 
+                              Time, histogram, [{truncate, false}]).
 
-% @private
-response() ->
-    exometer:update_or_create([hello, response], 1, counter, []),
-    exometer:update_or_create([hello, response, per_sec], 1, spiral, [{time_span, 1000}]).
-
-handle_request_time(Time) ->
-    exometer:update_or_create([hello, handle_request_time], Time, 
-                              histogram, [{truncate, false}]).
-
-% @private
 service(Value) -> 
     exometer:update_or_create([hello, services], Value, counter, []).
 
-% @private
 binding(Value) -> 
     exometer:update_or_create([hello, bindings], Value, counter, []).
 
-% @private
 listener(Value) -> 
     exometer:update_or_create([hello, listeners], Value, counter, []).
 
-% @private
 client(Value) -> 
     exometer:update_or_create([hello, clients], Value, counter, []).
 
+client_ok_request(Name) -> client_request(convert_name(Name), ok).
+
+client_error_request(Name) -> client_request(convert_name(Name), error).
+
+client_internal_request(Name) -> client_request(convert_name(Name), internal).
+
+client_request_handle_time(Name, Time) ->
+    exometer:update_or_create([hello, client, convert_name(Name), request, handle_time], 
+                              Time, histogram, [{truncate, false}]).
+
+client_ping_pong_latency(Name, Time) ->
+    exometer:update_or_create([hello, client, convert_name(Name), ping_pong_latency], 
+                              Time, histogram, [{truncate, false}]).
+
 %% --------------------------------------------------------------------------------
 %% -- Helpers
-packet(Type, Size) ->
-    exometer:update_or_create([hello, Type], 1, counter, []),
-    exometer:update_or_create([hello, Type, size], Size, histogram, []),
-    exometer:update_or_create([hello, Type, per_sec], 1, spiral, [{time_span, 1000}]).
+packet(Name, Type, Size) ->
+    exometer:update_or_create([hello, server, Name, Type, size], Size, histogram, []),
+    exometer:update_or_create([hello, server, Name, Type, per_sec], 1, spiral, [{time_span, 1000}]).
 
-request(Type, Value) ->
-    exometer:update_or_create([hello, request], Value, counter, []),
-    exometer:update_or_create([hello, request, Type], Value, counter, []),
-    exometer:update_or_create([hello, request, per_sec], Value, spiral, [{time_span, 1000}]).
+request(Name, Type, Value) ->
+    exometer:update_or_create([hello, server, Name, requests, Type, per_sec], Value, spiral, [{time_span, 1000}]).
+
+client_request(Name, Type) ->
+    exometer:update_or_create([hello, client, Name, requests, Type, per_sec], 1, 
+                              spiral, [{time_span, 1000}]).
+
+convert_name(Name) when is_atom(Name) -> Name;
+convert_name(Name) when is_list(Name) -> list_to_atom(Name);
+convert_name(Name) when is_binary(Name) -> convert_name(binary_to_list(Name));
+convert_name(Name) when is_pid(Name) -> convert_name(pid_to_list(Name)).

--- a/src/hello_proto.erl
+++ b/src/hello_proto.erl
@@ -68,19 +68,14 @@ handle_incoming_message(Context1, ProtocolMod, ProtocolOpts, Router, ExUriURL, S
     Context = Context1#context{connection_pid = self()},
     case decode(ProtocolMod, ProtocolOpts, Signature, Binary, request) of
         {ok, Requests} ->
-            Length = case Requests of Requests when is_list(Requests) -> length(Requests); _ -> 1 end,
-            hello_metrics:ok_request(Length),
             Result = proceed_incoming_message(Requests, Context, ProtocolMod, ProtocolOpts, Router, ExUriURL),
             may_be_encode(ProtocolMod, ProtocolOpts, Result);
         {error, ignore} ->
-            %log(ProtocolMod, Binary, undefined, undefined, ExUriURL),
-            hello_metrics:error_request(),
             ignore;
         {error, Response} ->
-            hello_metrics:error_request(),
             may_be_encode(ProtocolMod, ProtocolOpts, Response);
         {internal, Message} ->
-            hello_metrics:internal_request(),
+            hello_metrics:internal_request(Context#context.listener_id),
             ?MODULE:handle_internal(Context, Message) % for test
     end.
 
@@ -101,7 +96,6 @@ proceed_incoming_message(Request = #request{type = Type, proto_data = Info}, Con
 
 may_be_wait(_, #request{proto_data = Info}, _Context) ->
     Answer = hello_service:await(),
-    hello_metrics:response(),
     #response{proto_data = Info, response = proto_answer(Answer)};
 may_be_wait(async, _Request, _Context) ->
     ignore.


### PR DESCRIPTION
Add client metrics and refactor server side metrics for collecting it per listener.

Hello collects the following metrics via exometer_core and reports it to the each registered reporters:

* [hello, server, Name, packets_in, size] - histogram.
`mean` and `max` size of incoming packets on `Name` server.

* [hello, server, Name, packets_in, per_sec] - spiral.
Incoming packets per second on `Name` server.

* [hello, server, Name, packets_out, size] - histogram.
`mean` and `max` size of outcoming packets on `Name` server.

* [hello, server, Name, packets_out, per_sec] - spiral.
Outcoming packets per second on `Name` server.

* [hello, server, Name, requests, ReqType, per_sec] - spiral.
Requests per second on `Name` server with type `ReqType`.

* [hello, server, Name, request, handle_time] - histogram.
`mean` and `max` time of handling one request on `Name` server.

* [hello, client, Name, requests, ReqType, per_sec] - spiral.
Request per second on `Name` client with type `ReqType`.

* [hello, client, Name, request, handle_time] - histogram.
`mean` and `max` time of handling one request on `Name` client.

* [hello, client, Name, ping_pong_latency] - histogram.
`mean` and `max` time between ping and pong internal messages.

* [hello, services] - counter.
Counter of all available services.

* [hello, bindings] - counter.
Counter of all available bindings.

* [hello, listeners] - counter.
Counter of all available listeners.

* [hello, clients] - counter.
Counter of all available clients.

Name - server or client name
ReqType - ok, error, internal