### PR TITLE
Add server side notifications for zmq transport

### DIFF
--- a/include/hello.hrl
+++ b/include/hello.hrl
@@ -9,6 +9,7 @@
     transport               :: module(),
     transport_pid           :: pid(),
     transport_params        :: term(),
+    protocol_mod            :: protocol(),
     peer                    :: term(),
     session_id              :: term(),
     req_ref                 :: reference(),

--- a/test/handler1.erl
+++ b/test/handler1.erl
@@ -28,8 +28,8 @@ handle_request(Context, <<"handler1.fun4">>, [{_, Arg}], State) ->
     spawn(?MODULE, send_async_reply, [Context, Arg]),
 	{noreply, State + 1};
 handle_request(Context, <<"handler1.fun5">>, [{_, Arg}], State) ->
-	hello_handler:notify(Context, <<"notification">>, [<<"notification_arg1">>, <<"notification_arg2">>]),
-	{reply, {ok, Arg}, State + 1};
+    hello_handler:notify(Context, [<<"notification_arg1">>, <<"notification_arg2">>]),
+    {reply, {ok, Arg}, State + 1};
 handle_request(_Context, <<"handler1.fun6">>, [{<<"arg1">>, Arg1}, {<<"arg2">>, Arg2}], State) ->
 	{reply, {ok, [Arg1, Arg2]}, State + 1}.
 	

--- a/test/handler2.erl
+++ b/test/handler2.erl
@@ -28,8 +28,8 @@ handle_request(Context, <<"handler2.fun4">>, [{_, Arg}], State) ->
     spawn(?MODULE, send_async_reply, [Context, Arg]),
 	{noreply, State + 1};
 handle_request(Context, <<"handler2.fun5">>, [{_, Arg}], State) ->
-	hello_handler:notify(Context, <<"notification">>, [<<"notification_arg1">>, <<"notification_arg2">>]),
-	{reply, {ok, Arg}, State + 1}.
+    hello_handler:notify(Context, [<<"notification_arg1">>, <<"notification_arg2">>]),
+    {reply, {ok, Arg}, State + 1}.
 
 handle_info(_Context, _Message, State) ->
 	{noreply, State}.

--- a/test/jsonrpc_SUITE.erl
+++ b/test/jsonrpc_SUITE.erl
@@ -55,7 +55,7 @@ normal_batch_all_callbacks(_Config) ->
 notify(_Config) ->
 	Args = get_arg(?NOTIFY_REQS),
 	Requests = lists:zip(Args, ?NOTIFY_REQS),
-	[ {ok, Arg} = hello_client:call(ClientName, Request) || {_, ClientName} <- ?CLIENT_NAMES, {Arg, Request} <- Requests].
+	[{ok, Arg} = hello_client:call(zmq_tcp_client, Request) || {Arg, Request} <- Requests].
 
 all_mixed_batch_all_callbacks(_Config) ->
 	Request = shuffle_requests(?ALL_MIXED_BATCH_ALL_CALLBACKS),
@@ -103,7 +103,7 @@ all() ->
      all_mixed_batch_one_callback,
      normal_batch_all_callbacks,
      %all_mixed_batch_all_callbacks,
-     %notify,
+     notify,
      named_parameter,
      binding_not_found,
      method_not_found,
@@ -168,6 +168,7 @@ wait_clients() ->
         _ -> timer:sleep(1000), wait_clients()
     end.
 
+notification_fun([<<"notification_arg1">>, <<"notification_arg2">>]) -> ok;
 notification_fun(Args) when is_list(Args) ->
 	BatchArgs = [[A || {_, [A], _} <- Requests] || Requests <- ?BATCH_NOTIFICATION],
     case lists:member(Args, BatchArgs) of


### PR DESCRIPTION
1) Sending notification from server:

    handle_request(Context, _Fun, _Params, State) ->
        hello_handler:notify(Context, Event),
        {reply, {ok, ok}, State}.

2) Receiving notifications on client side:

    F = fun(Event) -> io:format("Event = ~p~n", [Event]),
    hello_client:start_supervised(client_name,
                                  "zmq-tcp://127.0.0.1:8088/test",
                                  [], [{notification_sink, F}], []),

__Note__: it works only over zmq+json-rpc