### PR TITLE
Metrics Rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,26 +128,30 @@ To write all requests for a module hello_handler_example to a file use:
 
 # Metrics
 
-Hello collects the following metrics via exometer_core and reports it to the each registered reporters: 
+Hello collects metrics via exometer. The following metrics are considered:
 
-| Exometer ID                                       | Type      | Data Types | Report Time |
-|---------------------------------------------------|-----------|------------|-------------|
-| [hello, server, Name, packets_in, size]           | histogram | max, mean  |   1000      |
-| [hello, server, Name, packets_in, per_sec]        | spiral    | one        |   1000      |
-| [hello, server, Name, packets_out, size]          | histogram | max, mean  |   1000      |
-| [hello, server, Name, packets_out, per_sec]       | spiral    | one        |   1000      |
-| [hello, server, Name, requests, ReqType, per_sec] | spiral    | one        |   1000      |
-| [hello, server, Name, request, handle_time]       | histogram | max, mean  |   1000      |
-| [hello, client, Name, requests, ReqType, per_sec] | spiral    | one        |   1000      |
-| [hello, client, Name, request, handle_time]       | histogram | max, mean  |   1000      |
-| [hello, client, Name, ping_pong_latency]          | histogram | max, mean  |   1000      |
-| [hello, services]                                 | counter   | value      |   2000      |
-| [hello, bindings]                                 | counter   | value      |   2000      |
-| [hello, listeners]                                | counter   | value      |   2000      |
-| [hello, clients]                                  | counter   | value      |   2000      |
+    * Request counter and request handle time in ms (listener, handler, client) grouped by
+      the types total, success, error and internal (for e.g. pings). For the
+      client also timeouts are available. The handle times for listeners and handlers
+      reflect the execution time of the callback modules.
+    * Last request time in ms (listener, handler, client)
+    * Last reset time in ms to see (re-) starts (listener, handler)
+    * uptime since last reset in ms (listener)
+    * packet in/out counter (listener)
+    * packet in/out size in bytes (listener)
 
-Name - server or client name
-ReqType = [ok, error, internal]
+Exometer entry types (see include/hello_metrics.hrl for definitions):
+
+    * Request counter/timeout and packet in/out counter: counter
+    * Request handle time and packet size: histogram
+    * Last request and last reset: gauge
+    * Uptime: function
+
+All histograms have a time span of 60s.
+
+Use `exometer_report:list_metrics([hello])` to see a full list of the exometer IDs.
+For listeners and clients the IDs are instantly visible after start. However, due to the dynamic handling
+of callback modules the IDs for handlers are only visible after the first call.
 
 # Elixir
 

--- a/include/hello_metrics.hrl
+++ b/include/hello_metrics.hrl
@@ -1,0 +1,91 @@
+%% This file contains the definitions for all metrics used by exometer.
+%%
+%% First the used entries and probes for exometer will be described and
+%% then the actual metrics. These definitions contain the way metrics are
+%% exposed, e.g. for requests:
+%%
+%%   - request handle time (gauge)
+%%   - request counter (counter)
+%%
+%% In a similar way this holds for other metrics.
+
+
+-type listener_metrics_name() :: atom().
+-type handler_metrics_name() :: atom().
+-type client_metrics_name() :: atom().
+-type atom_ip() :: atom().
+-type atom_port() :: atom().
+-type client_metrics_info() :: {client_metrics_name(), atom_ip(), atom_port()}.
+-type handler_metrics_info() :: {handler_metrics_name(), listener_metrics_name(), atom_ip(), atom_port()}.
+-type listener_metrics_info() :: {listener_metrics_name(), atom_ip(), atom_port()}.
+-type request_type() :: atom().
+-type packet_size() :: integer().
+
+
+%% this will be prepended to all eradius metrics
+-define(DEFAULT_ENTRIES, [hello]).
+
+-define(METRICS, [{listener, ?LISTENER_METRICS},
+                  {handler,  ?HANDLER_METRICS},
+                  {client,   ?CLIENT_METRICS}]).
+
+%% exometer basic configuration used for metrics
+-define(COUNTER,        {counter,   %% exometer type
+                         []}).      %% type options
+
+-define(GAUGE,          {gauge,
+                         []}).
+
+-define(HISTOGRAM_60000, {histogram,
+                         [{slot_period, 100},
+                          {time_span, 60000}]}).
+
+-define(FUNCTION_UPTIME,{{function,
+                          hello_metrics,
+                          update_listener_uptime,
+                          undefined,
+                          proplist,
+                          [value]},
+                         []}).
+
+-define(BASIC_REQUEST_METRICS, [
+     {request, total, [
+       {gauge, ?HISTOGRAM_60000},
+       {counter, ?COUNTER}]},
+     {request, success, [
+       {gauge, ?HISTOGRAM_60000},
+       {counter, ?COUNTER}]},
+     {request, error, [
+       {gauge, ?HISTOGRAM_60000},
+       {counter, ?COUNTER}]},
+
+     {time, last_request, [
+       {ticks, ?GAUGE}]}
+     ]).
+
+-define(LISTENER_METRICS, [
+     {request, internal, [
+       {gauge, ?HISTOGRAM_60000},
+       {counter, ?COUNTER}]},
+     {time, last_reset, [
+       {ticks, ?GAUGE}]},
+     {time, up, [
+       {ticks, ?FUNCTION_UPTIME}]},
+     {packet, in, [
+       {counter, ?COUNTER},
+       {size, ?HISTOGRAM_60000}]},
+     {packet, out, [
+       {counter, ?COUNTER},
+       {size, ?HISTOGRAM_60000}]}
+     ] ++ ?BASIC_REQUEST_METRICS).
+
+-define(CLIENT_METRICS, [
+     {request, internal, [
+       {gauge, ?HISTOGRAM_60000},
+       {counter, ?COUNTER}]},
+     {request, timeout, [
+       {gauge, ?HISTOGRAM_60000},
+       {counter, ?COUNTER}]}
+     ] ++ ?BASIC_REQUEST_METRICS).
+
+-define(HANDLER_METRICS, ?BASIC_REQUEST_METRICS).

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Hello.Mixfile do
   def application do
     [applications: [:lager, :exometer_core, :cowboy, :ex_uri, :ezmq, :hackney, :jsx],
      env: [{:dnssd, false},
-           {:metrics, [:client, :server, :common]},
+           {:metrics, [{:enabled, [:client, :listener, :handler]}]},
            {:default_protocol, :hello_proto_jsonrpc},
            {:transports, []},
            {:server_timeout, 10000},

--- a/src/hello.app.src
+++ b/src/hello.app.src
@@ -7,7 +7,7 @@
    {mod, {hello, []}},
    {env, [
        {dnssd, false},
-       {metrics, [client, server, common]},
+       {metrics, [{enabled, [client, listener, handler]}]},
        {default_protocol, hello_proto_jsonrpc},
        {transports, []},
        {server_timeout, 10000},

--- a/src/hello.erl
+++ b/src/hello.erl
@@ -53,7 +53,6 @@ start() ->
 start(_Type, _StartArgs) ->
     ok = start_dnssd(),
     {ok, Supervisor} = hello_supervisor:start_link(),
-    hello_metrics:start_subscriptions(),
     {ok, Supervisor, undefined}.
 
 % @doc Callback for application behaviour.

--- a/src/hello_proto.erl
+++ b/src/hello_proto.erl
@@ -75,23 +75,21 @@ handle_incoming_message(Context1, ProtocolMod, ProtocolOpts, Router, ExUriURL, S
         {error, Response} ->
             may_be_encode(ProtocolMod, ProtocolOpts, Response);
         {internal, Message} ->
-            hello_metrics:internal_request(Context#context.listener_id),
+            {AtomIP, AtomPort} = hello_metrics:atomize_ex_uri(ExUriURL),
+            MetricsInfo = {hello_metrics:to_atom(Context#context.listener_id), AtomIP, AtomPort},
+            hello_metrics:update_listener_request(internal, MetricsInfo, 0),
             ?MODULE:handle_internal(Context, Message) % for test
     end.
 
 proceed_incoming_message(Requests, Context, ProtocolMod, ProtocolOpts, Router, ExUriURL) when is_list(Requests) ->
     [proceed_incoming_message(Request, Context, ProtocolMod, ProtocolOpts, Router, ExUriURL) || {_, Request} <- Requests];
-proceed_incoming_message(Request = #request{type = Type, proto_data = Info}, Context, ProtocolMod, ProtocolOpts, Router, ExUriURL) ->
+proceed_incoming_message(Request = #request{type = Type, proto_data = Info}, Context, ProtocolMod, _ProtocolOpts, Router, ExUriURL) ->
     case Router:route(Context, Request, ExUriURL) of
         {ok, ServiceName, Identifier} ->
-            hello_service:call(ServiceName, Identifier, 
-                               Request#request{context = Context#context{ 
-                                                           protocol_mod = ProtocolMod}}),
+            hello_service:call(ServiceName, Identifier, Request#request{context = Context#context{protocol_mod = ProtocolMod}}, ExUriURL),
             may_be_wait(Type, Request, Context);
         {ok, ServiceName, Identifier, NewRequest} ->
-            hello_service:call(ServiceName, Identifier, 
-                               NewRequest#request{context = Context#context{
-                                                              protocol_mod = ProtocolMod}}),
+            hello_service:call(ServiceName, Identifier, NewRequest#request{context = Context#context{protocol_mod = ProtocolMod}}, ExUriURL),
             may_be_wait(Type, NewRequest, Context);
         {error, Error} = _ ->
             #response{proto_data = Info,

--- a/src/hello_service.erl
+++ b/src/hello_service.erl
@@ -1,5 +1,5 @@
 -module(hello_service).
--export([register_link/2, unregister_link/1, lookup/1, call/3, await/0, await/1, outgoing_message/2, all/0]).
+-export([register_link/2, unregister_link/1, lookup/1, call/3, call/4, await/0, await/1, outgoing_message/2, all/0]).
 -include("hello.hrl").
 -include("hello_log.hrl").
 
@@ -17,16 +17,20 @@ lookup(HandlerMod) ->
     Name = hello_lib:to_binary(HandlerMod:name()),
     hello_registry:lookup({service, Name}).
 
-call(Name, Identifier, {Method, Args}) ->
+call(Name, Identifier, Request) ->
+    call(Name, Identifier, Request, local).
+
+call(Name, Identifier, {Method, Args}, ExUriURL) ->
     Context = #context{connection_pid = self(), peer = make_ref()},
-    case call(Name, Identifier, #request{context = Context, method = Method, args = Args}) of
+    case call(Name, Identifier, #request{context = Context, method = Method, args = Args}, ExUriURL) of
         {error, method_not_found} = NotFound -> NotFound;
         _ -> await()
     end;
-call(Name, Identifier, Request) ->
+call(Name, Identifier, Request = #request{context = Context}, ExUriURL) ->
     case hello_registry:lookup({service, Name}) of
         {ok, _, {HandlerMod, HandlerArgs}} ->
-            Handler = hello_handler:get_handler(Name, Identifier, HandlerMod, HandlerArgs),
+            MetricsInfo = make_metrics_info(Name, Context#context.listener_id, ExUriURL),
+            Handler = hello_handler:get_handler(Name, Identifier, HandlerMod, HandlerArgs, MetricsInfo),
             hello_handler:process(Handler, Request);
         {error, not_found} ->
             ?LOG_WARNING("Service ~s not found.", [Name],
@@ -51,3 +55,12 @@ outgoing_message(_Context = #context{connection_pid = ConnectionPid}, Response) 
     ConnectionPid ! {?INCOMING_MSG, Response}.
 
 all() -> hello_registry:all(service).
+
+make_metrics_info(ServiceName, _ListenerId, local) ->
+    AtomServiceName = hello_metrics:to_atom(ServiceName),
+    {AtomServiceName, local, undefined, undefined};
+make_metrics_info(ServiceName, ListenerId, ExUriURL) ->
+    AtomListenerId = hello_metrics:to_atom(ListenerId),
+    {AtomListenerIP, AtomListenerPort} = hello_metrics:atomize_ex_uri(ExUriURL),
+    AtomServiceName = hello_metrics:to_atom(ServiceName),
+    {AtomServiceName, AtomListenerId, AtomListenerIP, AtomListenerPort}.

--- a/test/handler1.erl
+++ b/test/handler1.erl
@@ -11,13 +11,12 @@ name() -> 'app/test'.
  
 router_key() -> 'handler1'.
  
-validation() -> t.
 request(_Module, Method, Params) -> {ok, Method, Params}.
 
-init(A, Counter) ->
+init(_A, Counter) ->
 	{ok, Counter}.
 
-handle_request(_Context, <<"handler1.fun1">>, [{_, Arg}] = Args, State) ->
+handle_request(_Context, <<"handler1.fun1">>, [{_, Arg}] = _Args, State) ->
 	{reply, {ok, Arg}, State + 1};
 handle_request(_Context, <<"handler1.fun2">>, [{_, Arg}], State) ->
 	{reply, {ok, Arg}, State + 1};

--- a/test/handler2.erl
+++ b/test/handler2.erl
@@ -11,7 +11,6 @@ name() -> 'app2/test'.
  
 router_key() -> 'handler2'.
  
-validation() -> t.
 request(_Module, Method, Params) -> {ok, Method, Params}.
 
 init(_, Counter) ->

--- a/test/jsonrpc_SUITE.erl
+++ b/test/jsonrpc_SUITE.erl
@@ -152,7 +152,7 @@ start_named_client(Transport) ->
 	Name = proplists:get_value(Transport, ?CLIENT_NAMES),
 	{Url, TransportOpts} = Transport, 
 	ProtocolOpts = [{protocol, hello_proto_jsonrpc}, {notification_sink, fun notification_fun/1}],
-	{ok, _Pid} = hello_client:start_supervised(Name, Url ++ "/test", TransportOpts, ProtocolOpts, []).
+	{ok, _Pid} = hello_client:start_supervised(Name, Url, TransportOpts, ProtocolOpts, []).
 
 shuffle_requests(Reqs) ->
 	[ RandomReq || { _ , RandomReq} <- lists:sort([ {random:uniform(), Req} || Req <- Reqs])].


### PR DESCRIPTION
  * remove subscription mechanisms
  * remove counters for bindings, listeners, clients
  * add handler/service specific metrics for request counting
    and handle times
  * add uptime for listener
  * add last request metrics for client, handler/service and
    listener
  * request metrics are now distinguished by success, error and
    internal
  * all exometer ids are now uniformly formatted
  * all metrics are defined in include/hello_metrics.hrl which
    makes further refining easier