### PR TITLE
Add server side peer information to logging

### DIFF
--- a/include/hello_log.hrl
+++ b/include/hello_log.hrl
@@ -9,48 +9,50 @@
         lists:append([[{status_code, element(2, LogId)}, {message_id, element(1, LogId)}], Meta, ?DEFAULT_TRACES])).
 
 %% hello_handler specific log macros
--define(REQ_TRACES(Mod, HandlerId, Request, RequestStatus, Response, LogId),
-        lists:append([?REQ_TRACES(Mod, HandlerId, Request, RequestStatus, LogId), [{hello_response, hello_log:format(Response)}]])).
+-define(REQ_TRACES(Mod, HandlerId, Context, Request, RequestStatus, Response, LogId),
+        lists:append([?REQ_TRACES(Mod, HandlerId, Context, Request, RequestStatus, LogId), [{hello_response, hello_log:format(Response)}]])).
 
--define(REQ_TRACES(Mod, HandlerId, Request, RequestStatus, LogId),
+-define(REQ_TRACES(Mod, HandlerId, Context, Request, RequestStatus, LogId),
         ?DEFAULT_META([{hello_request, hello_log:format(Request)},
                        {hello_request_id, hello_log:get_id(Request)},
+                       {hello_request_peer, hello_log:format_context(peer, Context)},
                        {hello_request_method, hello_log:get_method(Request)},
                        {hello_request_status, RequestStatus},
                        {hello_service_id, HandlerId},
                        {hello_handler_callback, Mod}], LogId)).
 
--define(LOG_REQUEST_async_reply(CallbackModule, HandlerId, Request, Response, LogId),
-    lager:debug(?REQ_TRACES(CallbackModule, HandlerId, Request, ok, Response, LogId),
+-define(LOG_REQUEST_async_reply(CallbackModule, HandlerId, Context, Request, Response, LogId),
+    lager:debug(?REQ_TRACES(CallbackModule, HandlerId, Context, Request, ok, Response, LogId),
                 "~p / ~p : received request", [CallbackModule, hello_log:get_method(Request)])).
 
--define(LOG_REQUEST_request(CallbackModule, HandlerId, Request, Response, Time, LogId),
-    lager:debug(?REQ_TRACES(CallbackModule, HandlerId, Request, ok, Response, LogId),
+-define(LOG_REQUEST_request(CallbackModule, HandlerId, Context, Request, Response, Time, LogId),
+    lager:debug(?REQ_TRACES(CallbackModule, HandlerId, Context, Request, ok, Response, LogId),
                 "~p / ~p : received request [~w ms]", [CallbackModule, hello_log:get_method(Request), Time])).
 
--define(LOG_REQUEST_request_stop(CallbackModule, HandlerId, Request, Response, Reason, Time, LogId),
-    lager:info(lists:append(?REQ_TRACES(CallbackModule, HandlerId, Request, ok, Response, LogId), [{hello_error_reason, Reason}]),
+-define(LOG_REQUEST_request_stop(CallbackModule, HandlerId, Context, Request, Response, Reason, Time, LogId),
+    lager:info(lists:append(?REQ_TRACES(CallbackModule, HandlerId, Context, Request, ok, Response, LogId), [{hello_error_reason, Reason}]),
                "~p / ~p : received request [~w ms]", [CallbackModule, hello_log:get_method(Request), Time])).
 
--define(LOG_REQUEST_request_no_reply(CallbackModule, HandlerId, Request, Time, LogId),
-    lager:debug(?REQ_TRACES(CallbackModule, HandlerId, Request, ok, LogId),
+-define(LOG_REQUEST_request_no_reply(CallbackModule, HandlerId, Context, Request, Time, LogId),
+    lager:debug(?REQ_TRACES(CallbackModule, HandlerId, Context, Request, ok, LogId),
                 "~p / ~p : received request [~w ms]", [CallbackModule, hello_log:get_method(Request), Time])).
 
--define(LOG_REQUEST_request_stop_no_reply(CallbackModule, HandlerId, Request, Time, LogId),
-    lager:debug(?REQ_TRACES(CallbackModule, HandlerId, Request, ok, LogId),
+-define(LOG_REQUEST_request_stop_no_reply(CallbackModule, HandlerId, Context, Request, Time, LogId),
+    lager:debug(?REQ_TRACES(CallbackModule, HandlerId, Context, Request, ok, LogId),
                 "~p / ~p : received request [~w ms]", [CallbackModule, hello_log:get_method(Request), Time])).
 
--define(LOG_REQUEST_request_stop_no_reply(CallbackModule, HandlerId, Request, Reason, Time, LogId),
-    lager:debug(lists:append(?REQ_TRACES(CallbackModule, HandlerId, Request, ok, LogId), [{hello_error_reason, Reason}]),
+-define(LOG_REQUEST_request_stop_no_reply(CallbackModule, HandlerId, Context, Request, Reason, Time, LogId),
+    lager:debug(lists:append(?REQ_TRACES(CallbackModule, HandlerId, Context, Request, ok, LogId), [{hello_error_reason, Reason}]),
                 "~p / ~p : received request [~w ms]", [CallbackModule, hello_log:get_method(Request), Time])).
 
--define(LOG_REQUEST_bad_request(CallbackModule, HandlerId, Request, Reason, LogId),
-    lager:error(lists:append(?REQ_TRACES(CallbackModule, HandlerId, Request, error, LogId), [{hello_error_reason, Reason}]),
+-define(LOG_REQUEST_bad_request(CallbackModule, HandlerId, Context, Request, Reason, LogId),
+    lager:error(lists:append(?REQ_TRACES(CallbackModule, HandlerId, Context, Request, error, LogId), [{hello_error_reason, Reason}]),
                 "~p / ~p : received bad request", [CallbackModule, hello_log:get_method(Request)])).
 
--define(LOG_WARNING_reason(CallbackModule, HandlerId, Msg, Args, Reason, LogId),
+-define(LOG_WARNING_reason(CallbackModule, HandlerId, Context, Msg, Args, Reason, LogId),
     lager:error(?DEFAULT_META([{hello_handler_callback, CallbackModule},
                                {hello_error_reason, Reason},
+                               {hello_request_peer, hello_log:format_context(peer, Context)},
                                {hello_service_id, HandlerId}],
                               LogId), Msg, Args)).
 

--- a/src/hello_log.erl
+++ b/src/hello_log.erl
@@ -21,7 +21,7 @@
 % @private
 -module(hello_log).
 
--export([format/1, get_id/1, get_method/1]).
+-export([format/1, format_context/2, get_id/1, get_method/1]).
 
 -include("hello.hrl").
 
@@ -47,6 +47,16 @@ format(#response{id = ID, response = CallbackResponse}) ->
 format(ignore) -> ["ignored"];
 format({ok, CallbackResponse}) -> stringify(CallbackResponse);
 format(Msg) -> stringify(Msg).
+
+%% -- format parts of the request context
+%% There are three possible types of 'peer':
+%%   1. a reference when an internal 'service' is used
+%%   2. a ZeroMQ peer identity (a binary)
+%%   3. an IP with Port when HTTP is used
+format_context(peer, #context{peer = Peer}) when is_reference(Peer) -> "internal";
+format_context(peer, #context{peer = Peer}) when is_binary(Peer)    -> stringify(Peer);
+format_context(peer, #context{peer = {IP, _Port}})                  -> inet_parse:ntoa(IP);
+format_context(_, _)                                                -> "unavailable".
 
 %% -- get internal hello request id
 get_id([ #request{id = Id} ]) ->             stringify(Id);

--- a/test/hello_SUITE.erl
+++ b/test/hello_SUITE.erl
@@ -3,6 +3,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include("hello_test.hrl").
+-include("../include/hello.hrl").
 -include("../include/jsonrpc_internal.hrl").
 
 % ---------------------------------------------------------------------
@@ -117,6 +118,12 @@ time_metrics(_Config) ->
     true = Uptime > 0,
     ok.
 
+log_format(_Config) ->
+    "internal" = hello_log:format_context(peer, #context{peer = make_ref()}),
+    "127.0.0.1" = hello_log:format_context(peer, #context{peer = {{127, 0, 0, 1}, 8080}}),
+    "12345" = hello_log:format_context(peer, #context{peer = <<"12345">>}),
+    ok.
+
 % ---------------------------------------------------------------------
 % -- common_test callbacks
 all() ->
@@ -127,8 +134,9 @@ all() ->
      start_named_supervised,
      keep_alive,
      request_metrics,
-     time_metrics
-     ].
+     time_metrics,
+     log_format
+    ].
 
 init_per_suite(Config) ->
     hello:start(),


### PR DESCRIPTION
The new lager tracing field `hello_request_peer` can have the following values:

  * `internal` for internal (pure Erlang) communication
  * an IP like `127.0.0.1` when HTTP is used
  * an identity string which is generated by ZeroMQ