### PR TITLE
WIP: Fix: Resolve hostnames

### DIFF
--- a/src/hello_metrics.erl
+++ b/src/hello_metrics.erl
@@ -219,7 +219,7 @@ protocol("zmq-tcp6") -> inet6;
 protocol(_) -> inet.
 
 parse_ex_uri_ip(inet, "*") -> {ok, {0,0,0,0}};
-parse_ex_uri_ip(inet, Host) -> inet:parse_ipv4_address(Host);
+parse_ex_uri_ip(inet, Host) -> inet:getaddr(Host, inet);
 
 parse_ex_uri_ip(inet6, "*") -> {ok, {0,0,0,0,0,0,0,0}};
 parse_ex_uri_ip(inet6, Host) ->

--- a/src/hello_metrics.erl
+++ b/src/hello_metrics.erl
@@ -222,13 +222,8 @@ parse_ex_uri_ip(inet, "*") -> {ok, {0,0,0,0}};
 parse_ex_uri_ip(inet, Host) -> inet:getaddr(Host, inet);
 
 parse_ex_uri_ip(inet6, "*") -> {ok, {0,0,0,0,0,0,0,0}};
-parse_ex_uri_ip(inet6, Host) ->
-    case re:run(Host, "^\\[(.*)\\]$", [{capture, all, list}]) of
-        {match, ["[::1]", IP]} ->
-            inet:getaddr(Host, local);
-        _ ->
-            inet:getaddr(Host, inet6);
-    end.
+parse_ex_uri_ip(inet6, "[::1]") -> inet:getaddr("::1", inet6);
+parse_ex_uri_ip(inet6, Host) -> inet:getaddr(Host, inet6).
 
 atomize_ex_uri(#ex_uri{scheme = Scheme, authority = #ex_uri_authority{host = Host, port = Port}}) ->
     {ok, IP} = parse_ex_uri_ip(protocol(Scheme), Host),

--- a/src/hello_metrics.erl
+++ b/src/hello_metrics.erl
@@ -225,9 +225,9 @@ parse_ex_uri_ip(inet6, "*") -> {ok, {0,0,0,0,0,0,0,0}};
 parse_ex_uri_ip(inet6, Host) ->
     case re:run(Host, "^\\[(.*)\\]$", [{capture, all, list}]) of
         {match, ["[::1]", IP]} ->
-            inet:parse_ipv6_address(IP);
+            inet:getaddr(Host, local);
         _ ->
-            inet:parse_ipv6_address(Host)
+            inet:getaddr(Host, inet6);
     end.
 
 atomize_ex_uri(#ex_uri{scheme = Scheme, authority = #ex_uri_authority{host = Host, port = Port}}) ->

--- a/src/transports/hello_zmq_client.erl
+++ b/src/transports/hello_zmq_client.erl
@@ -96,7 +96,7 @@ ezmq_connect_url(Socket, URI = #ex_uri{authority = #ex_uri_authority{host = Host
     end.
 
 ezmq_ip(inet, "*") -> {ok, {0,0,0,0}};
-ezmq_ip(inet, Host) -> inet:parse_ipv4_address(Host);
+ezmq_ip(inet, Host) -> inet:getaddr(Host, inet);
 
 ezmq_ip(inet6, "*") -> {ok, {0,0,0,0,0,0,0,0}};
 ezmq_ip(inet6, Host) ->

--- a/src/transports/hello_zmq_client.erl
+++ b/src/transports/hello_zmq_client.erl
@@ -99,13 +99,9 @@ ezmq_ip(inet, "*") -> {ok, {0,0,0,0}};
 ezmq_ip(inet, Host) -> inet:getaddr(Host, inet);
 
 ezmq_ip(inet6, "*") -> {ok, {0,0,0,0,0,0,0,0}};
-ezmq_ip(inet6, Host) ->
-    case re:run(Host, "^\\[(.*)\\]$", [{capture, all, list}]) of
-        {match, ["[::1]", IP]} ->
-            inet:getaddr(Host, local);
-        _ ->
-            inet:getaddr(Host, inet6);
-    end.
+ezmq_ip(inet6, "[::1]") -> inet:getaddr("::1", inet6);
+ezmq_ip(inet6, Host) -> inet:getaddr(Host, inet6).
+
 
 clean_host(Host) ->
     HostSize = erlang:byte_size(Host),

--- a/src/transports/hello_zmq_client.erl
+++ b/src/transports/hello_zmq_client.erl
@@ -102,9 +102,9 @@ ezmq_ip(inet6, "*") -> {ok, {0,0,0,0,0,0,0,0}};
 ezmq_ip(inet6, Host) ->
     case re:run(Host, "^\\[(.*)\\]$", [{capture, all, list}]) of
         {match, ["[::1]", IP]} ->
-            inet:parse_ipv6_address(IP);
+            inet:getaddr(Host, local);
         _ ->
-            inet:parse_ipv6_address(Host)
+            inet:getaddr(Host, inet6);
     end.
 
 clean_host(Host) ->

--- a/src/transports/hello_zmq_listener.erl
+++ b/src/transports/hello_zmq_listener.erl
@@ -98,7 +98,7 @@ handle_info({zmq, _Socket, {Peer, Msg}}, State) ->
 handle_info({hello_msg, _Handler, Peer, Signature, Message}, State = #state{socket = Socket}) ->
     case ezmq:send(Socket, {Peer, [<<>>, Signature, Message]}) of
         ok -> ok;
-        Other -> 
+        Other ->
             ?LOG_WARNING("ZeroMQ listener error on sending message: ~s.", [Other],
                          [{hello_server_error, {error, cant_send_message}}], ?LOGID67)
     end,
@@ -145,7 +145,7 @@ ezmq_bind_url(Socket, URI = #ex_uri{authority = #ex_uri_authority{host = Host, p
     end.
 
 ezmq_ip(inet, "*") -> {ok, {0,0,0,0}};
-ezmq_ip(inet, Host) -> inet:parse_ipv4_address(Host);
+ezmq_ip(inet, Host) -> inet:getaddr(Host, inet);
 
 ezmq_ip(inet6, "*") -> {ok, {0,0,0,0,0,0,0,0}};
 ezmq_ip(inet6, Host) ->

--- a/src/transports/hello_zmq_listener.erl
+++ b/src/transports/hello_zmq_listener.erl
@@ -148,13 +148,8 @@ ezmq_ip(inet, "*") -> {ok, {0,0,0,0}};
 ezmq_ip(inet, Host) -> inet:getaddr(Host, inet);
 
 ezmq_ip(inet6, "*") -> {ok, {0,0,0,0,0,0,0,0}};
-ezmq_ip(inet6, Host) ->
-    case re:run(Host, "^\\[(.*)\\]$", [{capture, all, list}]) of
-        {match, ["[::1]", IP]} ->
-            inet:getaddr(Host, local);
-        _ ->
-            inet:getaddr(Host, inet6);
-    end.
+ezmq_ip(inet6, "[::1]") -> inet:getaddr("::1", inet6);
+ezmq_ip(inet6, Host) -> inet:getaddr(Host, inet6).
 
 gen_meta_fields(#state{encoded_url = EncUrl}) ->
     [{hello_transport, zmtp}, {hello_transport_url, EncUrl}].

--- a/src/transports/hello_zmq_listener.erl
+++ b/src/transports/hello_zmq_listener.erl
@@ -151,9 +151,9 @@ ezmq_ip(inet6, "*") -> {ok, {0,0,0,0,0,0,0,0}};
 ezmq_ip(inet6, Host) ->
     case re:run(Host, "^\\[(.*)\\]$", [{capture, all, list}]) of
         {match, ["[::1]", IP]} ->
-            inet:parse_ipv6_address(IP);
+            inet:getaddr(Host, local);
         _ ->
-            inet:parse_ipv6_address(Host)
+            inet:getaddr(Host, inet6);
     end.
 
 gen_meta_fields(#state{encoded_url = EncUrl}) ->


### PR DESCRIPTION
In a setup (like with docker) where hostnames stay the same but IPs may change
it is necessary to use hostnames in the config. This fix resolves hostnames.

I deployed the change in a docker setup with IPv4 addresses and it worked.